### PR TITLE
Add dynamic data path detection

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "dataPath": "src/data/"
+}


### PR DESCRIPTION
## Summary
- allow the game to locate JSON data dynamically
- search for a `config.json` file or attempt common relative paths
- load item data and other resources using the detected base path
- add `config.json` with default data path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887b8b71c8883329e0d1b83229cc109