### PR TITLE
feat: add data manager skeleton

### DIFF
--- a/docs/MODULAR_REFACTORING_PLAN.md
+++ b/docs/MODULAR_REFACTORING_PLAN.md
@@ -98,8 +98,8 @@ This document outlines a comprehensive refactoring plan to transform the current
 - [ ] Create system dependency resolution
 - [ ] Add system health monitoring and error handling
 
-#### **Task 1.3: Create Data Manager** 🔄 **DEFERRED**
-- [ ] Create `src/assets/js/managers/dataManager.js` - **Note**: Direct gameData access used for now
+#### **Task 1.3: Create Data Manager** 🔄 **IN PROGRESS**
+- [x] Create `src/assets/js/managers/dataManager.js` with basic load/caching
 - [ ] Centralize all game data access through manager
 - [ ] Implement data validation and schema enforcement
 - [ ] Add data change tracking and history
@@ -457,6 +457,7 @@ Event Bus → System Manager → Data Manager → Core Systems → UI Separation
 - ✅ **EventBus System**: Complete pub/sub system with global EVENTS constants
 - ✅ **BaseSystem Class**: Standard interface with lifecycle management (initialize/update/destroy)
 - ✅ **Modular Journal System**: First fully modularized system as proof of concept
+- ✅ **DataManager Module**: Initial centralized loader and cache for JSON data
 
 #### **Critical Bug Fixes:**
 - ✅ **Data Structure Fix**: Corrected `gameData.player.quests.completed` from `{}` to `[]`
@@ -474,9 +475,10 @@ Event Bus → System Manager → Data Manager → Core Systems → UI Separation
 - 🆕 `src/assets/js/systems/baseSystem.js` - System interface foundation
 - 🆕 `src/assets/js/systems/journal.js` - Complete modular journal system
 - 🔧 `src/assets/js/utils/core.js` - Fixed quest data structure
+- 🆕 `src/assets/js/managers/dataManager.js` - Centralized data loading and caching
 - 🔧 `src/assets/js/ui/ui.js` - Added modular system support with fallbacks
-- 🔧 `src/assets/js/core/main.js` - Enhanced initialization with system bootstrap
-- 🔧 `index.html` - Added test tools and updated script loading order
+- 🔧 `src/assets/js/core/main.js` - Enhanced initialization with system bootstrap and DataManager registration
+- 🔧 `index.html` - Added test tools, DataManager loader, and updated script order
 
 ### **Testing & Validation:**
 - ✅ **Automatic Testing**: Built-in test function runs on game load

--- a/index.html
+++ b/index.html
@@ -332,10 +332,13 @@
     <script src="src/assets/js/utils/debounce.js"></script>
     <script src="src/assets/js/utils/regionUtils.js"></script>
     <script src="src/assets/js/utils/scriptLoader.js"></script>
-  
+
     <!-- Core System Framework -->
     <script src="src/assets/js/core/eventBus.js"></script>
     <script src="src/assets/js/systems/baseSystem.js"></script>
+
+    <!-- Managers -->
+    <script src="src/assets/js/managers/dataManager.js"></script>
 
     <!-- Game Systems -->
     <script src="src/assets/js/systems/experience.js"></script>

--- a/src/assets/js/core/main.js
+++ b/src/assets/js/core/main.js
@@ -10,6 +10,12 @@ if (!window.showForagingProgressWithDice) {
 
 console.log('🎮 Main.js loaded successfully');
 
+// Initialize Data Manager and register core game data
+if (typeof DataManager !== 'undefined') {
+    window.dataManager = new DataManager();
+    dataManager.set('gameData', gameData);
+}
+
 // Helper function to map class skills to game skills
 function mapClassSkillToGameSkill(classSkill) {
     const skillMapping = {

--- a/src/assets/js/managers/dataManager.js
+++ b/src/assets/js/managers/dataManager.js
@@ -1,0 +1,48 @@
+(function (global) {
+  class DataManager {
+    constructor() {
+      this.cache = new Map();
+      this.basePath = '';
+    }
+
+    async init() {
+      if (!this.basePath && typeof global.detectDataPath === 'function') {
+        this.basePath = await global.detectDataPath();
+      }
+      return this.basePath;
+    }
+
+    async load(key, filename) {
+      const base = await this.init();
+      const response = await fetch(`${base}${filename}`, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to load ${filename}`);
+      }
+      const data = await response.json();
+      this.cache.set(key, data);
+      return data;
+    }
+
+    set(key, value) {
+      this.cache.set(key, value);
+    }
+
+    get(key) {
+      return this.cache.get(key);
+    }
+
+    has(key) {
+      return this.cache.has(key);
+    }
+
+    getAll() {
+      return Object.fromEntries(this.cache.entries());
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = DataManager;
+  } else {
+    global.DataManager = DataManager;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/managers/dataManager.test.js
+++ b/tests/managers/dataManager.test.js
@@ -1,0 +1,28 @@
+const DataManager = require('../../src/assets/js/managers/dataManager.js');
+
+describe('DataManager', () => {
+  beforeEach(() => {
+    global.detectDataPath = jest.fn().mockResolvedValue('');
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ value: 42 })
+      })
+    );
+  });
+
+  it('stores and retrieves values', () => {
+    const dm = new DataManager();
+    dm.set('test', { a: 1 });
+    expect(dm.get('test')).toEqual({ a: 1 });
+    expect(dm.has('test')).toBe(true);
+  });
+
+  it('loads JSON data and caches it', async () => {
+    const dm = new DataManager();
+    const data = await dm.load('sample', 'sample.json');
+    expect(global.fetch).toHaveBeenCalledWith('sample.json', { cache: 'no-store' });
+    expect(data).toEqual({ value: 42 });
+    expect(dm.get('sample')).toEqual({ value: 42 });
+  });
+});


### PR DESCRIPTION
## Summary
- add DataManager module for centralized JSON loading and caching
- register DataManager in main flow and load script in index
- document new data manager progress in modular refactoring plan and cover with tests

## Testing
- `NODE_PATH=. npm test` *(fails: missing modules in existing test suite)*
- `NODE_PATH=. npx jest tests/managers/dataManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6893a6df1fcc8332a914dece3452da89